### PR TITLE
explicitely set one region for storing logs

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     logging:
        driver: "awslogs"
        options:
-          awslogs-region: eu-west-1 # NOTE: explicitely store logs from all instances in one region, where they can be shipped to ElasticSearch and Kibana
+          awslogs-region: eu-west-1 # NOTE: we explicitely store logs from all instances in one region, where they can be shipped to ElasticSearch & vizualized in Kibana
           awslogs-group: "devnet"
           awslogs-stream: $NODE_NAME
-    restart: on-failure(3)
+    restart: on-failure(1)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     logging:
        driver: "awslogs"
        options:
-          awslogs-region: $AWS_REGION
+          awslogs-region: eu-west-1 # NOTE: explicitely store logs from all instances in one region, where they can be shipped to ElasticSearch and Kibana
           awslogs-group: "devnet"
           awslogs-stream: $NODE_NAME
-    restart: on-failure
+    restart: on-failure(3)

--- a/fabfile.py
+++ b/fabfile.py
@@ -87,7 +87,6 @@ def run_docker_compose(conn, pid):
         f.write(f'BASE_PATH=/tmp/{auth}\n')
         f.write(f'NODE_KEY_PATH=/tmp/{auth}/libp2p_secret\n')
         f.write(f'RESERVED_NODES="{reserved_nodes}"\n')
-        f.write('AWS_REGION=eu-west-1\n')
     conn.put(f'env{pid}', '.')
     conn.run(f'sudo mv env{pid} /etc/environment')
 
@@ -100,7 +99,6 @@ def run_docker_compose(conn, pid):
              f'export BASE_PATH=/tmp/{auth} &&'
              f'export NODE_KEY_PATH=/tmp/{auth}/libp2p_secret &&'
              f'export RESERVED_NODES="{reserved_nodes}" &&'
-             'export AWS_REGION=eu-west-1 &&'
              f'docker-compose -f docker-compose.yml up -d')
 
 


### PR DESCRIPTION
- explicitely set one region for storing logs (eu-west-1, where Kibana and Elastic is located)
- restart only three times on failure to avoid polluting logs if a node keeps panicking